### PR TITLE
Continue parsing when encountering field not present in xsd

### DIFF
--- a/src/xml/Parser.ts
+++ b/src/xml/Parser.ts
@@ -208,7 +208,7 @@ export class Parser {
 
 			state = state.parent;
 
-			if(member.proxy) {
+			if(member && member.proxy) {
 				if(item) state.item[member.safeName] = item;
 				item = state.item;
 


### PR DESCRIPTION
This applies the fix described by @davidspiess in https://github.com/charto/cxml/issues/14 

I'd like to use this package, but the XML I'm receiving from an external party sadly tends to have extra things which are not in their XSD.
Would it be possible to create a 0.1.2 release with this included?
I can't target a tag with my PR, but if you'd be so kind to create a branch at the current v0.1.1 tag, then I can retarget this PR and we can get this up and running fairly quickly.